### PR TITLE
implement test colinearity function

### DIFF
--- a/baby-stark/src/polynomial.rs
+++ b/baby-stark/src/polynomial.rs
@@ -174,9 +174,14 @@ impl Polynomial {
             None => Err("COULD_NOT_GET_MODULO".to_string())
         }
     }
+   
 
-    pub fn __xor__(self, exponent : i128) -> Polynomial {
-        // TBD
-        Polynomial::from(vec![FieldElement::new()])
+    fn test_colinearity(points: &[(i128, i128)]) -> bool {
+        let domain = points.iter().map(|&(x, _)| x).collect::<Vec<_>>();
+        let values = points.iter().map(|&(_, y)| y).collect::<Vec<_>>();
+        let polynomial = Polynomial::interpolate_domain(&domain, &values);// it depends on the interpolate_domain function done by Justin Fimbo
+        polynomial.degree() <= 1
     }
+
+
 }

--- a/baby-stark/src/polynomial.rs
+++ b/baby-stark/src/polynomial.rs
@@ -176,12 +176,15 @@ impl Polynomial {
     }
    
 
-    fn test_colinearity(points: &[(i128, i128)]) -> bool {
-        let domain = points.iter().map(|&(x, _)| x).collect::<Vec<_>>();
-        let values = points.iter().map(|&(_, y)| y).collect::<Vec<_>>();
-        let polynomial = Polynomial::interpolate_domain(&domain, &values);// it depends on the interpolate_domain function done by Justin Fimbo
+
+   pub fn test_colinearity(points: [FieldElement]) -> bool {
+        let domain: Vec<_> = points.iter().map(|point| point.clone()).collect();
+        let values: Vec<_> = points.iter().map(|point| point.clone()).collect();
+        let polynomial = Polynomial::interpolate_domain(domain, values);
         polynomial.degree() <= 1
     }
+    
+    
 
 
 }


### PR DESCRIPTION
This function takes a reference to a slice of tuples, where each tuple represents a point with an x and y coordinate. It then extracts the x and y coordinates into separate vectors, and uses those to interpolate a polynomial. If the degree of the polynomial is less than or equal to 1, the function returns true, indicating that the points are collinear. Otherwise, it returns false.